### PR TITLE
Feat: Add diagnostic logging for textarea clicks

### DIFF
--- a/content.ts
+++ b/content.ts
@@ -2,6 +2,7 @@ console.log("Content script loaded.");
 
 document.addEventListener('click', function(event) {
   const target = event.target as HTMLElement;
+  console.log("Clicked element tagName:", target.tagName);
   if (target.tagName.toLowerCase() === 'textarea') {
     console.log("Textarea clicked!");
     // Send a message to the popup or background script


### PR DESCRIPTION
I investigated the content script to understand why 'Textarea clicked!' logs were not appearing.

- I verified that the content script loads correctly.
- I added an additional console.log to output the tagName of any clicked element, to help diagnose event target issues.
- I confirmed that on a simple page, the 'Textarea clicked!' log appears as expected, indicating the core logic is sound.
- The issue of logs not appearing on a specific complex page is likely due to page-specific script interference or DOM structure, which I am not pursuing further at this time per your request.

The code is now ready with the additional diagnostic logging intact.